### PR TITLE
Fix rolino plugin errors and add features

### DIFF
--- a/rolino/includes/admin/class-rolino-admin-menu.php
+++ b/rolino/includes/admin/class-rolino-admin-menu.php
@@ -83,6 +83,16 @@ class Rolino_Admin_Menu {
             array($this, 'coupons_page')
         );
         
+        // Members submenu
+        add_submenu_page(
+            'rolino',
+            __('اعضا', 'rolino'),
+            __('اعضا', 'rolino'),
+            $capability,
+            'rolino-members',
+            array($this, 'members_page')
+        );
+        
         // SMS Scenarios submenu
         add_submenu_page(
             'rolino',
@@ -161,6 +171,14 @@ class Rolino_Admin_Menu {
     public function coupons_page() {
         $coupons_admin = new Rolino_Coupons_Admin();
         $coupons_admin->display_page();
+    }
+    
+    /**
+     * Members page
+     */
+    public function members_page() {
+        $members_admin = new Rolino_Members_Admin();
+        $members_admin->display_page();
     }
     
     /**

--- a/rolino/includes/admin/class-rolino-members-admin.php
+++ b/rolino/includes/admin/class-rolino-members-admin.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * Rolino Members Admin Class
+ * 
+ * Handles members/subscribers management in admin panel
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+class Rolino_Members_Admin {
+    
+    private $credits;
+    private $plans;
+    private $transactions;
+    
+    public function __construct() {
+        $this->credits = new Rolino_Credits();
+        $this->plans = new Rolino_Plans();
+        $this->transactions = new Rolino_Transactions();
+        
+        add_action('wp_ajax_rolino_save_member', array($this, 'ajax_save_member'));
+        add_action('wp_ajax_rolino_delete_member', array($this, 'ajax_delete_member'));
+        add_action('wp_ajax_rolino_extend_membership', array($this, 'ajax_extend_membership'));
+        add_action('wp_ajax_rolino_get_member_details', array($this, 'ajax_get_member_details'));
+    }
+    
+    /**
+     * Display members page
+     */
+    public function display_page() {
+        $tab = $_GET['tab'] ?? 'active';
+        
+        switch ($tab) {
+            case 'active':
+                $this->display_active_members();
+                break;
+                
+            case 'expired':
+                $this->display_expired_members();
+                break;
+                
+            case 'single_buy':
+                $this->display_single_buy_users();
+                break;
+                
+            default:
+                $this->display_active_members();
+                break;
+        }
+    }
+    
+    /**
+     * Display active members
+     */
+    private function display_active_members() {
+        $page = max(1, intval($_GET['paged'] ?? 1));
+        $per_page = 20;
+        $offset = ($page - 1) * $per_page;
+        
+        $members = $this->get_active_members($per_page, $offset);
+        $total_members = $this->get_active_members_count();
+        
+        $this->display_members_table($members, $total_members, $page, $per_page, 'active');
+    }
+    
+    /**
+     * Display expired members
+     */
+    private function display_expired_members() {
+        $page = max(1, intval($_GET['paged'] ?? 1));
+        $per_page = 20;
+        $offset = ($page - 1) * $per_page;
+        
+        $members = $this->get_expired_members($per_page, $offset);
+        $total_members = $this->get_expired_members_count();
+        
+        $this->display_members_table($members, $total_members, $page, $per_page, 'expired');
+    }
+    
+    /**
+     * Display single buy users
+     */
+    private function display_single_buy_users() {
+        $page = max(1, intval($_GET['paged'] ?? 1));
+        $per_page = 20;
+        $offset = ($page - 1) * $per_page;
+        
+        $users = $this->get_single_buy_users($per_page, $offset);
+        $total_users = $this->get_single_buy_users_count();
+        
+        $this->display_single_buy_table($users, $total_users, $page, $per_page);
+    }
+    
+    /**
+     * Display members table
+     */
+    private function display_members_table($members, $total_members, $page, $per_page, $tab) {
+        $total_pages = ceil($total_members / $per_page);
+        
+        include ROLINO_PLUGIN_PATH . 'templates/admin/members-table.php';
+    }
+    
+    /**
+     * Display single buy table
+     */
+    private function display_single_buy_table($users, $total_users, $page, $per_page) {
+        $total_pages = ceil($total_users / $per_page);
+        
+        include ROLINO_PLUGIN_PATH . 'templates/admin/single-buy-table.php';
+    }
+    
+    /**
+     * Get active members
+     */
+    private function get_active_members($limit = 20, $offset = 0) {
+        global $wpdb;
+        
+        $sql = "SELECT DISTINCT c.user_id, u.display_name, u.user_email, 
+                       MAX(c.end_time) as latest_end_time,
+                       SUM(c.credit) as total_credits,
+                       COUNT(c.id) as subscription_count
+                FROM {$wpdb->prefix}rolino_credits c
+                LEFT JOIN {$wpdb->users} u ON c.user_id = u.ID
+                WHERE c.end_time > NOW() AND c.plan_id > 0
+                GROUP BY c.user_id
+                ORDER BY latest_end_time DESC
+                LIMIT %d OFFSET %d";
+        
+        return $wpdb->get_results($wpdb->prepare($sql, $limit, $offset));
+    }
+    
+    /**
+     * Get active members count
+     */
+    private function get_active_members_count() {
+        global $wpdb;
+        
+        $sql = "SELECT COUNT(DISTINCT user_id) 
+                FROM {$wpdb->prefix}rolino_credits 
+                WHERE end_time > NOW() AND plan_id > 0";
+        
+        return $wpdb->get_var($sql);
+    }
+    
+    /**
+     * Get expired members
+     */
+    private function get_expired_members($limit = 20, $offset = 0) {
+        global $wpdb;
+        
+        $sql = "SELECT DISTINCT c.user_id, u.display_name, u.user_email, 
+                       MAX(c.end_time) as latest_end_time,
+                       SUM(c.credit) as total_credits,
+                       COUNT(c.id) as subscription_count
+                FROM {$wpdb->prefix}rolino_credits c
+                LEFT JOIN {$wpdb->users} u ON c.user_id = u.ID
+                WHERE c.end_time <= NOW() AND c.plan_id > 0
+                GROUP BY c.user_id
+                ORDER BY latest_end_time DESC
+                LIMIT %d OFFSET %d";
+        
+        return $wpdb->get_results($wpdb->prepare($sql, $limit, $offset));
+    }
+    
+    /**
+     * Get expired members count
+     */
+    private function get_expired_members_count() {
+        global $wpdb;
+        
+        $sql = "SELECT COUNT(DISTINCT user_id) 
+                FROM {$wpdb->prefix}rolino_credits 
+                WHERE end_time <= NOW() AND plan_id > 0";
+        
+        return $wpdb->get_var($sql);
+    }
+    
+    /**
+     * Get single buy users
+     */
+    private function get_single_buy_users($limit = 20, $offset = 0) {
+        global $wpdb;
+        
+        $sql = "SELECT DISTINCT c.user_id, u.display_name, u.user_email, 
+                       MAX(c.end_time) as latest_end_time,
+                       SUM(c.credit) as total_credits,
+                       COUNT(c.id) as purchase_count
+                FROM {$wpdb->prefix}rolino_credits c
+                LEFT JOIN {$wpdb->users} u ON c.user_id = u.ID
+                WHERE c.plan_id = 0
+                GROUP BY c.user_id
+                ORDER BY latest_end_time DESC
+                LIMIT %d OFFSET %d";
+        
+        return $wpdb->get_results($wpdb->prepare($sql, $limit, $offset));
+    }
+    
+    /**
+     * Get single buy users count
+     */
+    private function get_single_buy_users_count() {
+        global $wpdb;
+        
+        $sql = "SELECT COUNT(DISTINCT user_id) 
+                FROM {$wpdb->prefix}rolino_credits 
+                WHERE plan_id = 0";
+        
+        return $wpdb->get_var($sql);
+    }
+    
+    /**
+     * Get user subscriptions
+     */
+    public function get_user_subscriptions($user_id) {
+        global $wpdb;
+        
+        $sql = "SELECT c.*, p.plan_name 
+                FROM {$wpdb->prefix}rolino_credits c
+                LEFT JOIN {$wpdb->prefix}rolino_plans p ON c.plan_id = p.id
+                WHERE c.user_id = %d
+                ORDER BY c.start_time DESC";
+        
+        return $wpdb->get_results($wpdb->prepare($sql, $user_id));
+    }
+    
+    /**
+     * Get user single purchases
+     */
+    public function get_user_single_purchases($user_id) {
+        global $wpdb;
+        
+        $sql = "SELECT c.* 
+                FROM {$wpdb->prefix}rolino_credits c
+                WHERE c.user_id = %d AND c.plan_id = 0
+                ORDER BY c.start_time DESC";
+        
+        return $wpdb->get_results($wpdb->prepare($sql, $user_id));
+    }
+    
+    /**
+     * AJAX save member
+     */
+    public function ajax_save_member() {
+        check_ajax_referer('rolino_ajax_nonce', 'nonce');
+        
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => __('دسترسی ندارید', 'rolino')));
+        }
+        
+        $user_id = intval($_POST['user_id'] ?? 0);
+        $plan_id = intval($_POST['plan_id'] ?? 0);
+        $credits = intval($_POST['credits'] ?? 0);
+        $duration = intval($_POST['duration'] ?? 30);
+        
+        if (!$user_id || !$plan_id || $credits <= 0) {
+            wp_send_json_error(array('message' => __('لطفاً تمام فیلدها را پر کنید', 'rolino')));
+        }
+        
+        $result = $this->credits->add_credits($user_id, $plan_id, $credits, $duration);
+        
+        if ($result) {
+            wp_send_json_success(array('message' => __('اعتبار با موفقیت اضافه شد', 'rolino')));
+        } else {
+            wp_send_json_error(array('message' => __('خطا در اضافه کردن اعتبار', 'rolino')));
+        }
+    }
+    
+    /**
+     * AJAX delete member
+     */
+    public function ajax_delete_member() {
+        check_ajax_referer('rolino_ajax_nonce', 'nonce');
+        
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => __('دسترسی ندارید', 'rolino')));
+        }
+        
+        $user_id = intval($_POST['user_id'] ?? 0);
+        
+        if (!$user_id) {
+            wp_send_json_error(array('message' => __('شناسه کاربر نامعتبر است', 'rolino')));
+        }
+        
+        $result = $this->credits->delete_user_credits($user_id);
+        
+        if ($result) {
+            wp_send_json_success(array('message' => __('اعتبارهای کاربر حذف شد', 'rolino')));
+        } else {
+            wp_send_json_error(array('message' => __('خطا در حذف اعتبارها', 'rolino')));
+        }
+    }
+    
+    /**
+     * AJAX extend membership
+     */
+    public function ajax_extend_membership() {
+        check_ajax_referer('rolino_ajax_nonce', 'nonce');
+        
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => __('دسترسی ندارید', 'rolino')));
+        }
+        
+        $user_id = intval($_POST['user_id'] ?? 0);
+        $days = intval($_POST['days'] ?? 30);
+        
+        if (!$user_id || $days <= 0) {
+            wp_send_json_error(array('message' => __('لطفاً تعداد روزها را وارد کنید', 'rolino')));
+        }
+        
+        $result = $this->credits->extend_user_credits($user_id, $days);
+        
+        if ($result) {
+            wp_send_json_success(array('message' => __('اعتبار تمدید شد', 'rolino')));
+        } else {
+            wp_send_json_error(array('message' => __('خطا در تمدید اعتبار', 'rolino')));
+        }
+    }
+    
+    /**
+     * AJAX get member details
+     */
+    public function ajax_get_member_details() {
+        check_ajax_referer('rolino_ajax_nonce', 'nonce');
+        
+        if (!current_user_can('manage_options')) {
+            wp_send_json_error(array('message' => __('دسترسی ندارید', 'rolino')));
+        }
+        
+        $user_id = intval($_POST['user_id'] ?? 0);
+        
+        if (!$user_id) {
+            wp_send_json_error(array('message' => __('شناسه کاربر نامعتبر است', 'rolino')));
+        }
+        
+        $user = get_user_by('ID', $user_id);
+        if (!$user) {
+            wp_send_json_error(array('message' => __('کاربر یافت نشد', 'rolino')));
+        }
+        
+        $subscriptions = $this->get_user_subscriptions($user_id);
+        $single_purchases = $this->get_user_single_purchases($user_id);
+        
+        ob_start();
+        ?>
+        <div class="member-details">
+            <h3><?php echo esc_html($user->display_name); ?> (<?php echo esc_html($user->user_email); ?>)</h3>
+            
+            <h4><?php _e('اشتراک‌ها', 'rolino'); ?></h4>
+            <?php if (!empty($subscriptions)): ?>
+                <table class="wp-list-table widefat fixed striped">
+                    <thead>
+                        <tr>
+                            <th><?php _e('طرح', 'rolino'); ?></th>
+                            <th><?php _e('شروع', 'rolino'); ?></th>
+                            <th><?php _e('پایان', 'rolino'); ?></th>
+                            <th><?php _e('اعتبار', 'rolino'); ?></th>
+                            <th><?php _e('وضعیت', 'rolino'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($subscriptions as $subscription): ?>
+                            <tr>
+                                <td><?php echo esc_html($subscription->plan_name ?? __('نامشخص', 'rolino')); ?></td>
+                                <td><?php echo $this->format_date($subscription->start_time); ?></td>
+                                <td><?php echo $this->format_date($subscription->end_time); ?></td>
+                                <td><?php echo number_format($subscription->credit); ?></td>
+                                <td><?php echo $this->get_status_badge($subscription->end_time); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php else: ?>
+                <p><?php _e('هیچ اشتراکی یافت نشد', 'rolino'); ?></p>
+            <?php endif; ?>
+            
+            <h4><?php _e('خریدهای تکی', 'rolino'); ?></h4>
+            <?php if (!empty($single_purchases)): ?>
+                <table class="wp-list-table widefat fixed striped">
+                    <thead>
+                        <tr>
+                            <th><?php _e('تاریخ خرید', 'rolino'); ?></th>
+                            <th><?php _e('انقضا', 'rolino'); ?></th>
+                            <th><?php _e('اعتبار', 'rolino'); ?></th>
+                            <th><?php _e('وضعیت', 'rolino'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($single_purchases as $purchase): ?>
+                            <tr>
+                                <td><?php echo $this->format_date($purchase->start_time); ?></td>
+                                <td><?php echo $this->format_date($purchase->end_time); ?></td>
+                                <td><?php echo number_format($purchase->credit); ?></td>
+                                <td><?php echo $this->get_status_badge($purchase->end_time); ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            <?php else: ?>
+                <p><?php _e('هیچ خرید تکی یافت نشد', 'rolino'); ?></p>
+            <?php endif; ?>
+        </div>
+        <?php
+        $html = ob_get_clean();
+        
+        wp_send_json_success(array('html' => $html));
+    }
+    
+    /**
+     * Get status badge
+     */
+    public function get_status_badge($end_time) {
+        $now = current_time('mysql');
+        $end = new DateTime($end_time);
+        $current = new DateTime($now);
+        
+        if ($end > $current) {
+            $diff = $current->diff($end);
+            if ($diff->days <= 7) {
+                return '<span class="badge badge-warning">' . sprintf(__('%d روز باقی', 'rolino'), $diff->days) . '</span>';
+            } else {
+                return '<span class="badge badge-success">' . __('فعال', 'rolino') . '</span>';
+            }
+        } else {
+            return '<span class="badge badge-danger">' . __('منقضی شده', 'rolino') . '</span>';
+        }
+    }
+    
+    /**
+     * Format date
+     */
+    public function format_date($date) {
+        return date_i18n('Y/m/d H:i', strtotime($date));
+    }
+    
+    /**
+     * Get dashboard stats
+     */
+    public function get_dashboard_stats() {
+        $active_count = $this->get_active_members_count();
+        $expired_count = $this->get_expired_members_count();
+        $single_buy_count = $this->get_single_buy_users_count();
+        
+        return array(
+            'active' => $active_count,
+            'expired' => $expired_count,
+            'single_buy' => $single_buy_count,
+            'total' => $active_count + $expired_count + $single_buy_count
+        );
+    }
+}

--- a/rolino/includes/admin/class-rolino-sms-admin.php
+++ b/rolino/includes/admin/class-rolino-sms-admin.php
@@ -120,6 +120,29 @@ class Rolino_SMS_Admin {
      * Handle scenario save
      */
     private function handle_scenario_save() {
+        // Handle adding new scenario
+        if (isset($_POST['add_scenario']) && wp_verify_nonce($_POST['_wpnonce'], 'rolino_add_scenario')) {
+            $scenario_data = array(
+                'scenario_type' => intval($_POST['scenario_type'] ?? 0),
+                'days_offset' => $_POST['days_offset'] === '' ? null : intval($_POST['days_offset']),
+                'message_template' => sanitize_textarea_field($_POST['message_template'] ?? ''),
+                'status' => intval($_POST['status'] ?? 0)
+            );
+            
+            if ($scenario_data['scenario_type'] && !empty($scenario_data['message_template'])) {
+                $result = $this->sms->add_scenario($scenario_data);
+                if ($result) {
+                    $this->add_admin_notice(__('سناریو جدید اضافه شد', 'rolino'), 'success');
+                } else {
+                    $this->add_admin_notice(__('خطا در اضافه کردن سناریو', 'rolino'), 'error');
+                }
+            } else {
+                $this->add_admin_notice(__('لطفاً نوع سناریو و متن پیام را وارد کنید', 'rolino'), 'error');
+            }
+            return;
+        }
+        
+        // Handle updating existing scenarios
         if (!isset($_POST['save_scenarios']) || !wp_verify_nonce($_POST['_wpnonce'], 'rolino_sms_scenarios')) {
             return;
         }
@@ -145,27 +168,37 @@ class Rolino_SMS_Admin {
      * AJAX save scenario
      */
     public function ajax_save_scenario() {
-        check_ajax_referer('rolino_admin_nonce', 'nonce');
+        check_ajax_referer('rolino_ajax_nonce', 'nonce');
         
         if (!current_user_can('manage_options')) {
             wp_send_json_error(array('message' => __('دسترسی ندارید', 'rolino')));
         }
         
         $scenario_id = intval($_POST['scenario_id'] ?? 0);
+        $scenario_type = intval($_POST['scenario_type'] ?? 0);
         $data = array(
+            'scenario_type' => $scenario_type,
             'days_offset' => $_POST['days_offset'] === '' ? null : intval($_POST['days_offset']),
             'message_template' => sanitize_textarea_field($_POST['message_template'] ?? ''),
             'status' => intval($_POST['status'] ?? 0)
         );
         
-        if (!$scenario_id) {
-            wp_send_json_error(array('message' => __('شناسه سناریو نامعتبر است', 'rolino')));
+        if (!$scenario_type || empty($data['message_template'])) {
+            wp_send_json_error(array('message' => __('لطفاً نوع سناریو و متن پیام را وارد کنید', 'rolino')));
         }
         
-        $result = $this->sms->update_scenario($scenario_id, $data);
+        if ($scenario_id) {
+            // Update existing scenario
+            $result = $this->sms->update_scenario($scenario_id, $data);
+            $message = __('سناریو به‌روزرسانی شد', 'rolino');
+        } else {
+            // Add new scenario
+            $result = $this->sms->add_scenario($data);
+            $message = __('سناریو جدید اضافه شد', 'rolino');
+        }
         
         if ($result) {
-            wp_send_json_success(array('message' => __('سناریو ذخیره شد', 'rolino')));
+            wp_send_json_success(array('message' => $message));
         } else {
             wp_send_json_error(array('message' => __('خطا در ذخیره سناریو', 'rolino')));
         }

--- a/rolino/includes/core/class-rolino-credits.php
+++ b/rolino/includes/core/class-rolino-credits.php
@@ -546,4 +546,54 @@ class Rolino_Credits {
         
         return $info;
     }
+    
+    /**
+     * Add credits (alias for add_credit)
+     * 
+     * @param int $user_id
+     * @param int $plan_id
+     * @param int $credits
+     * @param int $duration
+     * @return bool
+     */
+    public function add_credits($user_id, $plan_id, $credits, $duration) {
+        return $this->add_credit($user_id, $plan_id, $credits, $duration);
+    }
+    
+    /**
+     * Delete user credits
+     * 
+     * @param int $user_id
+     * @return bool
+     */
+    public function delete_user_credits($user_id) {
+        global $wpdb;
+        
+        $result = $wpdb->delete(
+            $this->table_name,
+            array('user_id' => $user_id),
+            array('%d')
+        );
+        
+        return $result !== false;
+    }
+    
+    /**
+     * Extend user credits
+     * 
+     * @param int $user_id
+     * @param int $days
+     * @return bool
+     */
+    public function extend_user_credits($user_id, $days) {
+        global $wpdb;
+        
+        $sql = "UPDATE {$this->table_name} 
+                SET end_time = DATE_ADD(end_time, INTERVAL %d DAY) 
+                WHERE user_id = %d AND end_time > NOW()";
+        
+        $result = $wpdb->query($wpdb->prepare($sql, $days, $user_id));
+        
+        return $result !== false;
+    }
 }

--- a/rolino/includes/core/class-rolino-sms.php
+++ b/rolino/includes/core/class-rolino-sms.php
@@ -447,6 +447,31 @@ class Rolino_SMS {
     }
     
     /**
+     * Add scenario
+     * 
+     * @param array $data
+     * @return int|false
+     */
+    public function add_scenario($data) {
+        global $wpdb;
+        
+        $insert_data = array(
+            'scenario_type' => intval($data['scenario_type']),
+            'days_offset' => $data['days_offset'] === '' ? null : intval($data['days_offset']),
+            'message_template' => sanitize_textarea_field($data['message_template']),
+            'status' => intval($data['status'] ?? 1)
+        );
+        
+        $result = $wpdb->insert(
+            $this->scenarios_table,
+            $insert_data,
+            array('%d', '%d', '%s', '%d')
+        );
+        
+        return $result !== false ? $wpdb->insert_id : false;
+    }
+    
+    /**
      * Update scenario
      * 
      * @param int $scenario_id

--- a/rolino/rolino.php
+++ b/rolino/rolino.php
@@ -140,6 +140,7 @@ class Rolino {
         new Rolino_Admin_Menu();
         new Rolino_Plans_Admin();
         new Rolino_Coupons_Admin();
+        new Rolino_Members_Admin();
         new Rolino_SMS_Admin();
     }
     

--- a/rolino/rolino.php
+++ b/rolino/rolino.php
@@ -116,13 +116,11 @@ class Rolino {
         require_once ROLINO_PLUGIN_PATH . 'includes/gateways/ZarrinPalGateway.php';
         
         // Admin classes
-        if (is_admin()) {
-            require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-admin-menu.php';
-            require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-plans-admin.php';
-            require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-coupons-admin.php';
-            require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-members-admin.php';
-            require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-sms-admin.php';
-        }
+        require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-admin-menu.php';
+        require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-plans-admin.php';
+        require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-coupons-admin.php';
+        require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-members-admin.php';
+        require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-sms-admin.php';
         
         // Public classes
         require_once ROLINO_PLUGIN_PATH . 'includes/public/class-rolino-shortcodes.php';

--- a/rolino/rolino.php
+++ b/rolino/rolino.php
@@ -120,6 +120,7 @@ class Rolino {
             require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-admin-menu.php';
             require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-plans-admin.php';
             require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-coupons-admin.php';
+            require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-members-admin.php';
             require_once ROLINO_PLUGIN_PATH . 'includes/admin/class-rolino-sms-admin.php';
         }
         

--- a/rolino/templates/admin/coupon-form.php
+++ b/rolino/templates/admin/coupon-form.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * Coupon Form Template
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$coupon_id = isset($coupon) ? $coupon->id : 0;
+$is_edit = $coupon_id > 0;
+$form_title = $is_edit ? __('ویرایش کد تخفیف', 'rolino') : __('افزودن کد تخفیف جدید', 'rolino');
+$submit_text = $is_edit ? __('به‌روزرسانی کد تخفیف', 'rolino') : __('ایجاد کد تخفیف', 'rolino');
+
+// Default values
+$defaults = array(
+    'code' => '',
+    'type' => 1,
+    'start_date' => '',
+    'end_date' => '',
+    'usage_limit' => 0,
+    'status' => 1
+);
+
+$coupon_data = isset($coupon) ? (array) $coupon : $defaults;
+$coupon_types = array(
+    1 => __('درصدی', 'rolino'),
+    2 => __('مبلغ ثابت', 'rolino'),
+    3 => __('انحصاری', 'rolino')
+);
+?>
+
+<div class="wrap">
+    <h1><?php echo $form_title; ?></h1>
+    
+    <form method="post" id="rolino-coupon-form">
+        <?php wp_nonce_field('rolino_coupon_nonce', '_wpnonce'); ?>
+        <input type="hidden" name="coupon_id" value="<?php echo $coupon_id; ?>">
+        
+        <table class="form-table">
+            <tr>
+                <th scope="row">
+                    <label for="code"><?php _e('کد تخفیف', 'rolino'); ?> <span class="required">*</span></label>
+                </th>
+                <td>
+                    <input type="text" 
+                           id="code" 
+                           name="code" 
+                           value="<?php echo esc_attr($coupon_data['code']); ?>" 
+                           class="regular-text" 
+                           required>
+                    <button type="button" id="generate-code" class="button">
+                        <?php _e('تولید کد خودکار', 'rolino'); ?>
+                    </button>
+                    <p class="description"><?php _e('کد تخفیف منحصر به فرد', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="type"><?php _e('نوع تخفیف', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <select id="type" name="type">
+                        <?php foreach ($coupon_types as $type_id => $type_name): ?>
+                            <option value="<?php echo $type_id; ?>" <?php selected($coupon_data['type'], $type_id); ?>>
+                                <?php echo $type_name; ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                    <p class="description"><?php _e('نوع تخفیف اعمال شده', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="start_date"><?php _e('تاریخ شروع', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <input type="date" 
+                           id="start_date" 
+                           name="start_date" 
+                           value="<?php echo esc_attr($coupon_data['start_date']); ?>" 
+                           class="regular-text">
+                    <p class="description"><?php _e('تاریخ شروع اعتبار کد تخفیف', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="end_date"><?php _e('تاریخ پایان', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <input type="date" 
+                           id="end_date" 
+                           name="end_date" 
+                           value="<?php echo esc_attr($coupon_data['end_date']); ?>" 
+                           class="regular-text">
+                    <p class="description"><?php _e('تاریخ پایان اعتبار کد تخفیف', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="usage_limit"><?php _e('محدودیت استفاده', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <input type="number" 
+                           id="usage_limit" 
+                           name="usage_limit" 
+                           value="<?php echo esc_attr($coupon_data['usage_limit']); ?>" 
+                           class="small-text" 
+                           min="0">
+                    <p class="description"><?php _e('تعداد دفعات مجاز استفاده (0 = نامحدود)', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="status"><?php _e('وضعیت', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <select id="status" name="status">
+                        <option value="1" <?php selected($coupon_data['status'], 1); ?>><?php _e('فعال', 'rolino'); ?></option>
+                        <option value="0" <?php selected($coupon_data['status'], 0); ?>><?php _e('غیرفعال', 'rolino'); ?></option>
+                    </select>
+                    <p class="description"><?php _e('وضعیت فعال یا غیرفعال بودن کد تخفیف', 'rolino'); ?></p>
+                </td>
+            </tr>
+        </table>
+        
+        <!-- Plan Discounts Section -->
+        <h3><?php _e('تخفیف‌های طرح‌ها', 'rolino'); ?></h3>
+        <p class="description"><?php _e('برای هر طرح، درصد یا مبلغ تخفیف را مشخص کنید', 'rolino'); ?></p>
+        
+        <table class="wp-list-table widefat fixed striped">
+            <thead>
+                <tr>
+                    <th style="width: 200px;"><?php _e('نام طرح', 'rolino'); ?></th>
+                    <th style="width: 150px;"><?php _e('درصد تخفیف', 'rolino'); ?></th>
+                    <th style="width: 150px;"><?php _e('مبلغ تخفیف (تومان)', 'rolino'); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <?php if (!empty($all_plans)): ?>
+                    <?php foreach ($all_plans as $plan): ?>
+                        <?php 
+                        $plan_discount = isset($coupon_discounts[$plan->id]) ? $coupon_discounts[$plan->id] : array('percent' => 0, 'amount' => 0);
+                        ?>
+                        <tr>
+                            <td>
+                                <strong><?php echo esc_html($plan->plan_name); ?></strong>
+                                <p class="description"><?php echo number_format($plan->price); ?> تومان</p>
+                            </td>
+                            <td>
+                                <input type="number" 
+                                       name="plan_discounts[<?php echo $plan->id; ?>][percent]" 
+                                       value="<?php echo esc_attr($plan_discount['percent']); ?>" 
+                                       class="small-text" 
+                                       min="0" 
+                                       max="100" 
+                                       step="0.1">
+                                <span>%</span>
+                            </td>
+                            <td>
+                                <input type="number" 
+                                       name="plan_discounts[<?php echo $plan->id; ?>][amount]" 
+                                       value="<?php echo esc_attr($plan_discount['amount']); ?>" 
+                                       class="small-text" 
+                                       min="0" 
+                                       step="1000">
+                                <span>تومان</span>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php else: ?>
+                    <tr>
+                        <td colspan="3"><?php _e('هیچ طرح فعالی یافت نشد', 'rolino'); ?></td>
+                    </tr>
+                <?php endif; ?>
+            </tbody>
+        </table>
+        
+        <p class="submit">
+            <button type="submit" class="button button-primary" id="save-coupon">
+                <?php echo $submit_text; ?>
+            </button>
+            <a href="<?php echo admin_url('admin.php?page=rolino-coupons'); ?>" class="button">
+                <?php _e('انصراف', 'rolino'); ?>
+            </a>
+        </p>
+    </form>
+</div>
+
+<script>
+jQuery(document).ready(function($) {
+    // Generate coupon code
+    $('#generate-code').on('click', function() {
+        var chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+        var code = '';
+        for (var i = 0; i < 8; i++) {
+            code += chars.charAt(Math.floor(Math.random() * chars.length));
+        }
+        $('#code').val(code);
+    });
+    
+    // Form submission
+    $('#rolino-coupon-form').on('submit', function(e) {
+        e.preventDefault();
+        
+        var formData = $(this).serialize();
+        formData += '&action=rolino_save_coupon&nonce=' + rolino_ajax.nonce;
+        
+        $('#save-coupon').prop('disabled', true).text('<?php _e('در حال ذخیره...', 'rolino'); ?>');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: formData,
+            success: function(response) {
+                if (response.success) {
+                    alert(response.data.message);
+                    window.location.href = '<?php echo admin_url('admin.php?page=rolino-coupons'); ?>';
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در ذخیره کد تخفیف', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            },
+            complete: function() {
+                $('#save-coupon').prop('disabled', false).text('<?php echo $submit_text; ?>');
+            }
+        });
+    });
+});
+</script>

--- a/rolino/templates/admin/members-table.php
+++ b/rolino/templates/admin/members-table.php
@@ -1,0 +1,450 @@
+<?php
+/**
+ * Members Table Template
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$members_admin = new Rolino_Members_Admin();
+$plans = new Rolino_Plans();
+$all_plans = $plans->get_active_plans();
+?>
+
+<div class="wrap">
+    <h1><?php _e('مدیریت اعضا', 'rolino'); ?></h1>
+    
+    <!-- Tab Navigation -->
+    <nav class="nav-tab-wrapper">
+        <a href="<?php echo admin_url('admin.php?page=rolino-members&tab=active'); ?>" 
+           class="nav-tab <?php echo $tab === 'active' ? 'nav-tab-active' : ''; ?>">
+            <?php _e('اعضای فعال', 'rolino'); ?>
+        </a>
+        <a href="<?php echo admin_url('admin.php?page=rolino-members&tab=expired'); ?>" 
+           class="nav-tab <?php echo $tab === 'expired' ? 'nav-tab-active' : ''; ?>">
+            <?php _e('منقضی شده', 'rolino'); ?>
+        </a>
+        <a href="<?php echo admin_url('admin.php?page=rolino-members&tab=single_buy'); ?>" 
+           class="nav-tab <?php echo $tab === 'single_buy' ? 'nav-tab-active' : ''; ?>">
+            <?php _e('خرید تکی', 'rolino'); ?>
+        </a>
+    </nav>
+    
+    <!-- Add Member Form -->
+    <div class="postbox" style="margin: 20px 0;">
+        <h2 class="hndle"><?php _e('افزودن عضو جدید', 'rolino'); ?></h2>
+        <div class="inside">
+            <form method="post" id="add-member-form">
+                <?php wp_nonce_field('rolino_add_member', '_wpnonce'); ?>
+                
+                <table class="form-table">
+                    <tr>
+                        <th scope="row">
+                            <label for="user_id"><?php _e('کاربر', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <select id="user_id" name="user_id" required>
+                                <option value=""><?php _e('انتخاب کاربر', 'rolino'); ?></option>
+                                <?php
+                                $users = get_users(array('orderby' => 'display_name'));
+                                foreach ($users as $user) {
+                                    echo '<option value="' . $user->ID . '">' . esc_html($user->display_name) . ' (' . $user->user_email . ')</option>';
+                                }
+                                ?>
+                            </select>
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <th scope="row">
+                            <label for="plan_id"><?php _e('طرح', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <select id="plan_id" name="plan_id" required>
+                                <option value=""><?php _e('انتخاب طرح', 'rolino'); ?></option>
+                                <?php foreach ($all_plans as $plan): ?>
+                                    <option value="<?php echo $plan->id; ?>">
+                                        <?php echo esc_html($plan->plan_name); ?> - <?php echo number_format($plan->price); ?> تومان
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <th scope="row">
+                            <label for="credits"><?php _e('تعداد اعتبار', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" 
+                                   id="credits" 
+                                   name="credits" 
+                                   value="1" 
+                                   min="1" 
+                                   class="small-text" 
+                                   required>
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <th scope="row">
+                            <label for="duration"><?php _e('مدت اعتبار (روز)', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" 
+                                   id="duration" 
+                                   name="duration" 
+                                   value="30" 
+                                   min="1" 
+                                   max="3650" 
+                                   class="small-text" 
+                                   required>
+                        </td>
+                    </tr>
+                </table>
+                
+                <p class="submit">
+                    <button type="submit" class="button button-primary">
+                        <?php _e('افزودن عضو', 'rolino'); ?>
+                    </button>
+                </p>
+            </form>
+        </div>
+    </div>
+    
+    <!-- Members Table -->
+    <div class="postbox">
+        <h2 class="hndle">
+            <?php 
+            if ($tab === 'active') {
+                _e('اعضای فعال', 'rolino');
+            } elseif ($tab === 'expired') {
+                _e('اعضای منقضی شده', 'rolino');
+            }
+            ?>
+        </h2>
+        <div class="inside">
+            <?php if (!empty($members)): ?>
+                <table class="wp-list-table widefat fixed striped">
+                    <thead>
+                        <tr>
+                            <th><?php _e('کاربر', 'rolino'); ?></th>
+                            <th><?php _e('ایمیل', 'rolino'); ?></th>
+                            <th><?php _e('آخرین انقضا', 'rolino'); ?></th>
+                            <th><?php _e('مجموع اعتبار', 'rolino'); ?></th>
+                            <th><?php _e('تعداد اشتراک', 'rolino'); ?></th>
+                            <th><?php _e('وضعیت', 'rolino'); ?></th>
+                            <th><?php _e('عملیات', 'rolino'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($members as $member): ?>
+                            <tr>
+                                <td>
+                                    <strong><?php echo esc_html($member->display_name); ?></strong>
+                                </td>
+                                <td><?php echo esc_html($member->user_email); ?></td>
+                                <td><?php echo $members_admin->format_date($member->latest_end_time); ?></td>
+                                <td><?php echo number_format($member->total_credits); ?></td>
+                                <td><?php echo number_format($member->subscription_count); ?></td>
+                                <td><?php echo $members_admin->get_status_badge($member->latest_end_time); ?></td>
+                                <td>
+                                    <button type="button" 
+                                            class="button button-small view-details" 
+                                            data-user-id="<?php echo $member->user_id; ?>">
+                                        <?php _e('جزئیات', 'rolino'); ?>
+                                    </button>
+                                    
+                                    <?php if ($tab === 'expired'): ?>
+                                        <button type="button" 
+                                                class="button button-small extend-membership" 
+                                                data-user-id="<?php echo $member->user_id; ?>">
+                                            <?php _e('تمدید', 'rolino'); ?>
+                                        </button>
+                                    <?php endif; ?>
+                                    
+                                    <button type="button" 
+                                            class="button button-small button-link-delete delete-member" 
+                                            data-user-id="<?php echo $member->user_id; ?>">
+                                        <?php _e('حذف', 'rolino'); ?>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                
+                <!-- Pagination -->
+                <?php if ($total_pages > 1): ?>
+                    <div class="tablenav">
+                        <div class="tablenav-pages">
+                            <?php
+                            $current_url = admin_url('admin.php?page=rolino-members&tab=' . $tab);
+                            
+                            if ($page > 1) {
+                                echo '<a href="' . add_query_arg('paged', $page - 1, $current_url) . '" class="prev page-numbers">' . __('قبلی', 'rolino') . '</a>';
+                            }
+                            
+                            for ($i = 1; $i <= $total_pages; $i++) {
+                                if ($i == $page) {
+                                    echo '<span class="page-numbers current">' . $i . '</span>';
+                                } else {
+                                    echo '<a href="' . add_query_arg('paged', $i, $current_url) . '" class="page-numbers">' . $i . '</a>';
+                                }
+                            }
+                            
+                            if ($page < $total_pages) {
+                                echo '<a href="' . add_query_arg('paged', $page + 1, $current_url) . '" class="next page-numbers">' . __('بعدی', 'rolino') . '</a>';
+                            }
+                            ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
+            <?php else: ?>
+                <p><?php _e('هیچ عضوی یافت نشد', 'rolino'); ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+
+<!-- Member Details Modal -->
+<div id="member-details-modal" class="modal" style="display: none;">
+    <div class="modal-content">
+        <span class="close">&times;</span>
+        <h2><?php _e('جزئیات عضو', 'rolino'); ?></h2>
+        <div id="member-details-content"></div>
+    </div>
+</div>
+
+<!-- Extend Membership Modal -->
+<div id="extend-membership-modal" class="modal" style="display: none;">
+    <div class="modal-content">
+        <span class="close">&times;</span>
+        <h2><?php _e('تمدید عضویت', 'rolino'); ?></h2>
+        <form id="extend-membership-form">
+            <table class="form-table">
+                <tr>
+                    <th scope="row">
+                        <label for="extend_days"><?php _e('تعداد روز', 'rolino'); ?></label>
+                    </th>
+                    <td>
+                        <input type="number" 
+                               id="extend_days" 
+                               name="days" 
+                               value="30" 
+                               min="1" 
+                               max="3650" 
+                               class="small-text" 
+                               required>
+                    </td>
+                </tr>
+            </table>
+            <p class="submit">
+                <button type="submit" class="button button-primary">
+                    <?php _e('تمدید', 'rolino'); ?>
+                </button>
+            </p>
+        </form>
+    </div>
+</div>
+
+<style>
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: #fefefe;
+    margin: 5% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 600px;
+    border-radius: 5px;
+}
+
+.close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.badge {
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.badge-success {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.badge-warning {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+.badge-danger {
+    background-color: #f8d7da;
+    color: #721c24;
+}
+</style>
+
+<script>
+jQuery(document).ready(function($) {
+    // Add member form
+    $('#add-member-form').on('submit', function(e) {
+        e.preventDefault();
+        
+        var formData = $(this).serialize();
+        formData += '&action=rolino_save_member&nonce=' + rolino_ajax.nonce;
+        
+        var submitBtn = $(this).find('button[type="submit"]');
+        var originalText = submitBtn.text();
+        
+        submitBtn.prop('disabled', true).text('<?php _e('در حال ذخیره...', 'rolino'); ?>');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: formData,
+            success: function(response) {
+                if (response.success) {
+                    alert(response.data.message);
+                    location.reload();
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در ذخیره عضو', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            },
+            complete: function() {
+                submitBtn.prop('disabled', false).text(originalText);
+            }
+        });
+    });
+    
+    // View member details
+    $('.view-details').on('click', function() {
+        var userId = $(this).data('user-id');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'rolino_get_member_details',
+                user_id: userId,
+                nonce: rolino_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    $('#member-details-content').html(response.data.html);
+                    $('#member-details-modal').show();
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در دریافت جزئیات', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            }
+        });
+    });
+    
+    // Extend membership
+    $('.extend-membership').on('click', function() {
+        var userId = $(this).data('user-id');
+        $('#extend-membership-form').data('user-id', userId);
+        $('#extend-membership-modal').show();
+    });
+    
+    $('#extend-membership-form').on('submit', function(e) {
+        e.preventDefault();
+        
+        var userId = $(this).data('user-id');
+        var days = $('#extend_days').val();
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'rolino_extend_membership',
+                user_id: userId,
+                days: days,
+                nonce: rolino_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    alert(response.data.message);
+                    location.reload();
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در تمدید عضویت', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            }
+        });
+    });
+    
+    // Delete member
+    $('.delete-member').on('click', function() {
+        if (!confirm('<?php _e('آیا مطمئن هستید که می‌خواهید این عضو را حذف کنید؟', 'rolino'); ?>')) {
+            return;
+        }
+        
+        var userId = $(this).data('user-id');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'rolino_delete_member',
+                user_id: userId,
+                nonce: rolino_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    alert(response.data.message);
+                    location.reload();
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در حذف عضو', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            }
+        });
+    });
+    
+    // Modal close
+    $('.close').on('click', function() {
+        $('.modal').hide();
+    });
+    
+    $(window).on('click', function(e) {
+        if ($(e.target).hasClass('modal')) {
+            $('.modal').hide();
+        }
+    });
+});
+</script>

--- a/rolino/templates/admin/plan-form.php
+++ b/rolino/templates/admin/plan-form.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Plan Form Template
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$plan_id = isset($plan) ? $plan->id : 0;
+$is_edit = $plan_id > 0;
+$form_title = $is_edit ? __('ویرایش طرح', 'rolino') : __('افزودن طرح جدید', 'rolino');
+$submit_text = $is_edit ? __('به‌روزرسانی طرح', 'rolino') : __('ایجاد طرح', 'rolino');
+
+// Default values
+$defaults = array(
+    'plan_name' => '',
+    'credits' => 0,
+    'duration' => 30,
+    'price' => 0,
+    'active_sessions' => 1,
+    'status' => 1
+);
+
+$plan_data = isset($plan) ? (array) $plan : $defaults;
+?>
+
+<div class="wrap">
+    <h1><?php echo $form_title; ?></h1>
+    
+    <form method="post" id="rolino-plan-form">
+        <?php wp_nonce_field('rolino_plan_nonce', '_wpnonce'); ?>
+        <input type="hidden" name="plan_id" value="<?php echo $plan_id; ?>">
+        
+        <table class="form-table">
+            <tr>
+                <th scope="row">
+                    <label for="plan_name"><?php _e('نام طرح', 'rolino'); ?> <span class="required">*</span></label>
+                </th>
+                <td>
+                    <input type="text" 
+                           id="plan_name" 
+                           name="plan_name" 
+                           value="<?php echo esc_attr($plan_data['plan_name']); ?>" 
+                           class="regular-text" 
+                           required>
+                    <p class="description"><?php _e('نام منحصر به فرد برای طرح', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="credits"><?php _e('تعداد اعتبار', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <input type="number" 
+                           id="credits" 
+                           name="credits" 
+                           value="<?php echo esc_attr($plan_data['credits']); ?>" 
+                           class="small-text" 
+                           min="0">
+                    <p class="description"><?php _e('تعداد اعتبارهای قابل استفاده در این طرح', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="duration"><?php _e('مدت اعتبار (روز)', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <input type="number" 
+                           id="duration" 
+                           name="duration" 
+                           value="<?php echo esc_attr($plan_data['duration']); ?>" 
+                           class="small-text" 
+                           min="1" 
+                           max="3650">
+                    <p class="description"><?php _e('مدت زمان اعتبار طرح به روز', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="price"><?php _e('قیمت (تومان)', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <input type="number" 
+                           id="price" 
+                           name="price" 
+                           value="<?php echo esc_attr($plan_data['price']); ?>" 
+                           class="regular-text" 
+                           min="0" 
+                           step="1000">
+                    <p class="description"><?php _e('قیمت طرح به تومان', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="active_sessions"><?php _e('تعداد نشست‌های همزمان', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <input type="number" 
+                           id="active_sessions" 
+                           name="active_sessions" 
+                           value="<?php echo esc_attr($plan_data['active_sessions']); ?>" 
+                           class="small-text" 
+                           min="1" 
+                           max="10">
+                    <p class="description"><?php _e('تعداد نشست‌های همزمان مجاز', 'rolino'); ?></p>
+                </td>
+            </tr>
+            
+            <tr>
+                <th scope="row">
+                    <label for="status"><?php _e('وضعیت', 'rolino'); ?></label>
+                </th>
+                <td>
+                    <select id="status" name="status">
+                        <option value="1" <?php selected($plan_data['status'], 1); ?>><?php _e('فعال', 'rolino'); ?></option>
+                        <option value="0" <?php selected($plan_data['status'], 0); ?>><?php _e('غیرفعال', 'rolino'); ?></option>
+                    </select>
+                    <p class="description"><?php _e('وضعیت فعال یا غیرفعال بودن طرح', 'rolino'); ?></p>
+                </td>
+            </tr>
+        </table>
+        
+        <p class="submit">
+            <button type="submit" class="button button-primary" id="save-plan">
+                <?php echo $submit_text; ?>
+            </button>
+            <a href="<?php echo admin_url('admin.php?page=rolino-plans'); ?>" class="button">
+                <?php _e('انصراف', 'rolino'); ?>
+            </a>
+        </p>
+    </form>
+</div>
+
+<script>
+jQuery(document).ready(function($) {
+    $('#rolino-plan-form').on('submit', function(e) {
+        e.preventDefault();
+        
+        var formData = $(this).serialize();
+        formData += '&action=rolino_save_plan&nonce=' + rolino_ajax.nonce;
+        
+        $('#save-plan').prop('disabled', true).text('<?php _e('در حال ذخیره...', 'rolino'); ?>');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: formData,
+            success: function(response) {
+                if (response.success) {
+                    alert(response.data.message);
+                    window.location.href = '<?php echo admin_url('admin.php?page=rolino-plans'); ?>';
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در ذخیره طرح', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            },
+            complete: function() {
+                $('#save-plan').prop('disabled', false).text('<?php echo $submit_text; ?>');
+            }
+        });
+    });
+});
+</script>

--- a/rolino/templates/admin/single-buy-table.php
+++ b/rolino/templates/admin/single-buy-table.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Single Buy Table Template
+ */
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+$members_admin = new Rolino_Members_Admin();
+?>
+
+<div class="wrap">
+    <h1><?php _e('خریدهای تکی', 'rolino'); ?></h1>
+    
+    <!-- Tab Navigation -->
+    <nav class="nav-tab-wrapper">
+        <a href="<?php echo admin_url('admin.php?page=rolino-members&tab=active'); ?>" 
+           class="nav-tab">
+            <?php _e('اعضای فعال', 'rolino'); ?>
+        </a>
+        <a href="<?php echo admin_url('admin.php?page=rolino-members&tab=expired'); ?>" 
+           class="nav-tab">
+            <?php _e('منقضی شده', 'rolino'); ?>
+        </a>
+        <a href="<?php echo admin_url('admin.php?page=rolino-members&tab=single_buy'); ?>" 
+           class="nav-tab nav-tab-active">
+            <?php _e('خرید تکی', 'rolino'); ?>
+        </a>
+    </nav>
+    
+    <!-- Single Buy Table -->
+    <div class="postbox">
+        <h2 class="hndle"><?php _e('کاربران خرید تکی', 'rolino'); ?></h2>
+        <div class="inside">
+            <?php if (!empty($users)): ?>
+                <table class="wp-list-table widefat fixed striped">
+                    <thead>
+                        <tr>
+                            <th><?php _e('کاربر', 'rolino'); ?></th>
+                            <th><?php _e('ایمیل', 'rolino'); ?></th>
+                            <th><?php _e('آخرین خرید', 'rolino'); ?></th>
+                            <th><?php _e('مجموع اعتبار', 'rolino'); ?></th>
+                            <th><?php _e('تعداد خرید', 'rolino'); ?></th>
+                            <th><?php _e('وضعیت', 'rolino'); ?></th>
+                            <th><?php _e('عملیات', 'rolino'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($users as $user): ?>
+                            <tr>
+                                <td>
+                                    <strong><?php echo esc_html($user->display_name); ?></strong>
+                                </td>
+                                <td><?php echo esc_html($user->user_email); ?></td>
+                                <td><?php echo $members_admin->format_date($user->latest_end_time); ?></td>
+                                <td><?php echo number_format($user->total_credits); ?></td>
+                                <td><?php echo number_format($user->purchase_count); ?></td>
+                                <td><?php echo $members_admin->get_status_badge($user->latest_end_time); ?></td>
+                                <td>
+                                    <button type="button" 
+                                            class="button button-small view-details" 
+                                            data-user-id="<?php echo $user->user_id; ?>">
+                                        <?php _e('جزئیات', 'rolino'); ?>
+                                    </button>
+                                    
+                                    <button type="button" 
+                                            class="button button-small button-link-delete delete-member" 
+                                            data-user-id="<?php echo $user->user_id; ?>">
+                                        <?php _e('حذف', 'rolino'); ?>
+                                    </button>
+                                </td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                
+                <!-- Pagination -->
+                <?php if ($total_pages > 1): ?>
+                    <div class="tablenav">
+                        <div class="tablenav-pages">
+                            <?php
+                            $current_url = admin_url('admin.php?page=rolino-members&tab=single_buy');
+                            
+                            if ($page > 1) {
+                                echo '<a href="' . add_query_arg('paged', $page - 1, $current_url) . '" class="prev page-numbers">' . __('قبلی', 'rolino') . '</a>';
+                            }
+                            
+                            for ($i = 1; $i <= $total_pages; $i++) {
+                                if ($i == $page) {
+                                    echo '<span class="page-numbers current">' . $i . '</span>';
+                                } else {
+                                    echo '<a href="' . add_query_arg('paged', $i, $current_url) . '" class="page-numbers">' . $i . '</a>';
+                                }
+                            }
+                            
+                            if ($page < $total_pages) {
+                                echo '<a href="' . add_query_arg('paged', $page + 1, $current_url) . '" class="next page-numbers">' . __('بعدی', 'rolino') . '</a>';
+                            }
+                            ?>
+                        </div>
+                    </div>
+                <?php endif; ?>
+            <?php else: ?>
+                <p><?php _e('هیچ کاربر خرید تکی یافت نشد', 'rolino'); ?></p>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+
+<!-- Member Details Modal -->
+<div id="member-details-modal" class="modal" style="display: none;">
+    <div class="modal-content">
+        <span class="close">&times;</span>
+        <h2><?php _e('جزئیات کاربر', 'rolino'); ?></h2>
+        <div id="member-details-content"></div>
+    </div>
+</div>
+
+<style>
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.4);
+}
+
+.modal-content {
+    background-color: #fefefe;
+    margin: 5% auto;
+    padding: 20px;
+    border: 1px solid #888;
+    width: 80%;
+    max-width: 600px;
+    border-radius: 5px;
+}
+
+.close {
+    color: #aaa;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.close:hover,
+.close:focus {
+    color: black;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+.badge {
+    padding: 4px 8px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+}
+
+.badge-success {
+    background-color: #d4edda;
+    color: #155724;
+}
+
+.badge-warning {
+    background-color: #fff3cd;
+    color: #856404;
+}
+
+.badge-danger {
+    background-color: #f8d7da;
+    color: #721c24;
+}
+</style>
+
+<script>
+jQuery(document).ready(function($) {
+    // View user details
+    $('.view-details').on('click', function() {
+        var userId = $(this).data('user-id');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'rolino_get_member_details',
+                user_id: userId,
+                nonce: rolino_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    $('#member-details-content').html(response.data.html);
+                    $('#member-details-modal').show();
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در دریافت جزئیات', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            }
+        });
+    });
+    
+    // Delete user
+    $('.delete-member').on('click', function() {
+        if (!confirm('<?php _e('آیا مطمئن هستید که می‌خواهید این کاربر را حذف کنید؟', 'rolino'); ?>')) {
+            return;
+        }
+        
+        var userId = $(this).data('user-id');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'rolino_delete_member',
+                user_id: userId,
+                nonce: rolino_ajax.nonce
+            },
+            success: function(response) {
+                if (response.success) {
+                    alert(response.data.message);
+                    location.reload();
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در حذف کاربر', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            }
+        });
+    });
+    
+    // Modal close
+    $('.close').on('click', function() {
+        $('.modal').hide();
+    });
+    
+    $(window).on('click', function(e) {
+        if ($(e.target).hasClass('modal')) {
+            $('.modal').hide();
+        }
+    });
+});
+</script>

--- a/rolino/templates/admin/sms-scenarios.php
+++ b/rolino/templates/admin/sms-scenarios.php
@@ -38,67 +38,162 @@ $available_variables = $sms_admin->get_available_variables();
         </details>
     </div>
     
-    <form method="post" action="">
-        <?php wp_nonce_field('rolino_sms_scenarios', '_wpnonce'); ?>
-        <input type="hidden" name="save_scenarios" value="1">
-        
-        <table class="wp-list-table widefat fixed striped">
-            <thead>
-                <tr>
-                    <th style="width: 200px;"><?php _e('نوع سناریو', 'rolino'); ?></th>
-                    <th style="width: 120px;"><?php _e('فاصله (روز)', 'rolino'); ?></th>
-                    <th><?php _e('قالب پیام', 'rolino'); ?></th>
-                    <th style="width: 100px;"><?php _e('وضعیت', 'rolino'); ?></th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php if (!empty($scenarios)): ?>
-                    <?php foreach ($scenarios as $scenario): ?>
-                        <tr>
-                            <td>
-                                <strong><?php echo esc_html($scenario_types[$scenario->scenario_type] ?? __('نامشخص', 'rolino')); ?></strong>
-                                <p class="description"><?php echo $sms_admin->get_scenario_description($scenario->scenario_type); ?></p>
-                            </td>
-                            <td>
-                                <?php if (in_array($scenario->scenario_type, [1, 2, 3])): ?>
-                                    <input type="number" 
-                                           name="scenarios[<?php echo $scenario->id; ?>][days_offset]" 
-                                           value="<?php echo esc_attr($scenario->days_offset); ?>" 
-                                           min="0" 
-                                           max="365" 
-                                           class="small-text">
-                                <?php else: ?>
-                                    <span class="description"><?php _e('فوری', 'rolino'); ?></span>
-                                    <input type="hidden" name="scenarios[<?php echo $scenario->id; ?>][days_offset]" value="">
-                                <?php endif; ?>
-                            </td>
-                            <td>
-                                <textarea name="scenarios[<?php echo $scenario->id; ?>][message_template]" 
-                                          rows="3" 
-                                          style="width: 100%;"
-                                          placeholder="<?php _e('متن پیام را وارد کنید...', 'rolino'); ?>"><?php echo esc_textarea($scenario->message_template); ?></textarea>
-                            </td>
-                            <td>
-                                <label class="switch">
-                                    <input type="checkbox" 
-                                           name="scenarios[<?php echo $scenario->id; ?>][status]" 
-                                           value="1" 
-                                           <?php checked($scenario->status, 1); ?>>
-                                    <span class="slider round"></span>
-                                </label>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                <?php else: ?>
+    <!-- Add New Scenario Form -->
+    <div class="postbox" style="margin-bottom: 20px;">
+        <h2 class="hndle"><?php _e('افزودن سناریو جدید', 'rolino'); ?></h2>
+        <div class="inside">
+            <form method="post" action="" id="add-scenario-form">
+                <?php wp_nonce_field('rolino_add_scenario', '_wpnonce'); ?>
+                <input type="hidden" name="add_scenario" value="1">
+                
+                <table class="form-table">
                     <tr>
-                        <td colspan="4"><?php _e('هیچ سناریویی یافت نشد', 'rolino'); ?></td>
+                        <th scope="row">
+                            <label for="scenario_type"><?php _e('نوع سناریو', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <select id="scenario_type" name="scenario_type" required>
+                                <option value=""><?php _e('انتخاب کنید', 'rolino'); ?></option>
+                                <?php foreach ($scenario_types as $type_id => $type_name): ?>
+                                    <option value="<?php echo $type_id; ?>"><?php echo $type_name; ?></option>
+                                <?php endforeach; ?>
+                            </select>
+                            <p class="description" id="scenario-description"></p>
+                        </td>
                     </tr>
-                <?php endif; ?>
-            </tbody>
-        </table>
-        
-        <?php submit_button(__('ذخیره سناریوها', 'rolino')); ?>
-    </form>
+                    
+                    <tr>
+                        <th scope="row">
+                            <label for="days_offset"><?php _e('فاصله (روز)', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <input type="number" 
+                                   id="days_offset" 
+                                   name="days_offset" 
+                                   value="0" 
+                                   min="0" 
+                                   max="365" 
+                                   class="small-text">
+                            <p class="description"><?php _e('تعداد روز قبل یا بعد از رویداد', 'rolino'); ?></p>
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <th scope="row">
+                            <label for="message_template"><?php _e('قالب پیام', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <textarea id="message_template" 
+                                      name="message_template" 
+                                      rows="4" 
+                                      style="width: 100%;"
+                                      placeholder="<?php _e('متن پیام را وارد کنید...', 'rolino'); ?>"
+                                      required></textarea>
+                            <p class="description"><?php _e('از متغیرهای پویا استفاده کنید، مثال: {{user_name}}', 'rolino'); ?></p>
+                        </td>
+                    </tr>
+                    
+                    <tr>
+                        <th scope="row">
+                            <label for="status"><?php _e('وضعیت', 'rolino'); ?></label>
+                        </th>
+                        <td>
+                            <label>
+                                <input type="checkbox" 
+                                       id="status" 
+                                       name="status" 
+                                       value="1" 
+                                       checked>
+                                <?php _e('فعال', 'rolino'); ?>
+                            </label>
+                        </td>
+                    </tr>
+                </table>
+                
+                <p class="submit">
+                    <button type="submit" class="button button-primary">
+                        <?php _e('افزودن سناریو', 'rolino'); ?>
+                    </button>
+                </p>
+            </form>
+        </div>
+    </div>
+    
+    <!-- Existing Scenarios -->
+    <div class="postbox">
+        <h2 class="hndle"><?php _e('سناریوهای موجود', 'rolino'); ?></h2>
+        <div class="inside">
+            <form method="post" action="">
+                <?php wp_nonce_field('rolino_sms_scenarios', '_wpnonce'); ?>
+                <input type="hidden" name="save_scenarios" value="1">
+                
+                <table class="wp-list-table widefat fixed striped">
+                    <thead>
+                        <tr>
+                            <th style="width: 200px;"><?php _e('نوع سناریو', 'rolino'); ?></th>
+                            <th style="width: 120px;"><?php _e('فاصله (روز)', 'rolino'); ?></th>
+                            <th><?php _e('قالب پیام', 'rolino'); ?></th>
+                            <th style="width: 100px;"><?php _e('وضعیت', 'rolino'); ?></th>
+                            <th style="width: 80px;"><?php _e('عملیات', 'rolino'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php if (!empty($scenarios)): ?>
+                            <?php foreach ($scenarios as $scenario): ?>
+                                <tr>
+                                    <td>
+                                        <strong><?php echo esc_html($scenario_types[$scenario->scenario_type] ?? __('نامشخص', 'rolino')); ?></strong>
+                                        <p class="description"><?php echo $sms_admin->get_scenario_description($scenario->scenario_type); ?></p>
+                                    </td>
+                                    <td>
+                                        <?php if (in_array($scenario->scenario_type, [1, 2, 3])): ?>
+                                            <input type="number" 
+                                                   name="scenarios[<?php echo $scenario->id; ?>][days_offset]" 
+                                                   value="<?php echo esc_attr($scenario->days_offset); ?>" 
+                                                   min="0" 
+                                                   max="365" 
+                                                   class="small-text">
+                                        <?php else: ?>
+                                            <span class="description"><?php _e('فوری', 'rolino'); ?></span>
+                                            <input type="hidden" name="scenarios[<?php echo $scenario->id; ?>][days_offset]" value="">
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <textarea name="scenarios[<?php echo $scenario->id; ?>][message_template]" 
+                                                  rows="3" 
+                                                  style="width: 100%;"
+                                                  placeholder="<?php _e('متن پیام را وارد کنید...', 'rolino'); ?>"><?php echo esc_textarea($scenario->message_template); ?></textarea>
+                                    </td>
+                                    <td>
+                                        <label class="switch">
+                                            <input type="checkbox" 
+                                                   name="scenarios[<?php echo $scenario->id; ?>][status]" 
+                                                   value="1" 
+                                                   <?php checked($scenario->status, 1); ?>>
+                                            <span class="slider round"></span>
+                                        </label>
+                                    </td>
+                                    <td>
+                                        <a href="<?php echo admin_url('admin.php?page=rolino-sms-scenarios&action=delete&scenario_id=' . $scenario->id . '&_wpnonce=' . wp_create_nonce('delete_scenario')); ?>" 
+                                           class="button button-small button-link-delete"
+                                           onclick="return confirm('<?php _e('آیا مطمئن هستید که می‌خواهید این سناریو را حذف کنید؟', 'rolino'); ?>')">
+                                            <?php _e('حذف', 'rolino'); ?>
+                                        </a>
+                                    </td>
+                                </tr>
+                            <?php endforeach; ?>
+                        <?php else: ?>
+                            <tr>
+                                <td colspan="5"><?php _e('هیچ سناریویی یافت نشد', 'rolino'); ?></td>
+                            </tr>
+                        <?php endif; ?>
+                    </tbody>
+                </table>
+                
+                <?php submit_button(__('ذخیره سناریوها', 'rolino')); ?>
+            </form>
+        </div>
+    </div>
     
     <!-- Test SMS Form -->
     <div class="postbox" style="margin-top: 20px;">
@@ -208,6 +303,63 @@ input:checked + .slider:before {
 
 <script>
 jQuery(document).ready(function($) {
+    // Scenario type descriptions
+    var scenarioDescriptions = {
+        '1': '<?php _e('ارسال پیام قبل از انقضای اعتبار', 'rolino'); ?>',
+        '2': '<?php _e('ارسال پیام بعد از انقضای اعتبار', 'rolino'); ?>',
+        '3': '<?php _e('ارسال پیام قبل از انقضای اعتبار گروه', 'rolino'); ?>',
+        '4': '<?php _e('ارسال پیام هنگام خرید طرح', 'rolino'); ?>',
+        '5': '<?php _e('ارسال پیام هنگام خرید تکی', 'rolino'); ?>',
+        '6': '<?php _e('ارسال پیام هنگام فعال‌سازی کد تخفیف', 'rolino'); ?>'
+    };
+    
+    // Update scenario description when type changes
+    $('#scenario_type').on('change', function() {
+        var type = $(this).val();
+        var description = scenarioDescriptions[type] || '';
+        $('#scenario-description').text(description);
+        
+        // Show/hide days offset field based on scenario type
+        if ([1, 2, 3].indexOf(parseInt(type)) !== -1) {
+            $('#days_offset').closest('tr').show();
+        } else {
+            $('#days_offset').closest('tr').hide();
+        }
+    });
+    
+    // Add scenario form submission
+    $('#add-scenario-form').on('submit', function(e) {
+        e.preventDefault();
+        
+        var formData = $(this).serialize();
+        formData += '&action=rolino_save_sms_scenario&nonce=' + rolino_ajax.nonce;
+        
+        var submitBtn = $(this).find('button[type="submit"]');
+        var originalText = submitBtn.text();
+        
+        submitBtn.prop('disabled', true).text('<?php _e('در حال ذخیره...', 'rolino'); ?>');
+        
+        $.ajax({
+            url: rolino_ajax.ajax_url,
+            type: 'POST',
+            data: formData,
+            success: function(response) {
+                if (response.success) {
+                    alert(response.data.message);
+                    location.reload();
+                } else {
+                    alert(response.data.message || '<?php _e('خطا در ذخیره سناریو', 'rolino'); ?>');
+                }
+            },
+            error: function() {
+                alert('<?php _e('خطا در ارتباط با سرور', 'rolino'); ?>');
+            },
+            complete: function() {
+                submitBtn.prop('disabled', false).text(originalText);
+            }
+        });
+    });
+    
     // Test SMS form
     $('#test-sms-form').on('submit', function(e) {
         e.preventDefault();
@@ -221,13 +373,13 @@ jQuery(document).ready(function($) {
         }
         
         $.ajax({
-            url: ajaxurl,
+            url: rolino_ajax.ajax_url,
             type: 'POST',
             data: {
                 action: 'rolino_test_sms',
                 phone: phone,
                 message: message,
-                nonce: rolinoAdmin.nonce
+                nonce: rolino_ajax.nonce
             },
             success: function(response) {
                 if (response.success) {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes missing plan/coupon forms, enhances SMS scenario management, and adds a comprehensive member management page to address reported errors and missing features.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user reported `include()` errors for `plan-form.php` and `coupon-form.php`, indicating these essential templates were missing. Additionally, the SMS scenario page lacked the ability to add new scenarios, and there was no dedicated interface to view, add, extend, or delete members/subscribers, including those with single purchases or expired plans. This PR addresses all these core functional gaps.

---
<a href="https://cursor.com/background-agent?bcId=bc-6321b3a0-cd18-47ff-ad7b-33f74be7f5ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6321b3a0-cd18-47ff-ad7b-33f74be7f5ae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>